### PR TITLE
fix not handled truv events and add haptic to success screen

### DIFF
--- a/Sources/TruvSDK/Classes/Handlers/TruvScriptMessageHandler.swift
+++ b/Sources/TruvSDK/Classes/Handlers/TruvScriptMessageHandler.swift
@@ -24,7 +24,6 @@ final class TruvScriptMessageHandler: NSObject, WKScriptMessageHandler {
             let eventPayload = payload["payload"] as? [String: Any]
         {
             handleExternalAuthorization(body: body, eventPayload: eventPayload, eventType: eventType)
-            return
         }
         
         if
@@ -33,7 +32,6 @@ final class TruvScriptMessageHandler: NSObject, WKScriptMessageHandler {
             let name = TruvEventType(rawValue: eventName)
         {
             handleEvent(body: body, event: name)
-            return
         }
     }
 }

--- a/Sources/TruvSDK/Classes/Handlers/TruvScriptMessageHandler.swift
+++ b/Sources/TruvSDK/Classes/Handlers/TruvScriptMessageHandler.swift
@@ -23,7 +23,10 @@ final class TruvScriptMessageHandler: NSObject, WKScriptMessageHandler {
             let eventType = payload["event_type"] as? String,
             let eventPayload = payload["payload"] as? [String: Any]
         {
-            handleExternalAuthorization(body: body, eventPayload: eventPayload, eventType: eventType)
+            if eventType == "START_EXTERNAL_LOGIN" || eventType == "OAUTH_OPENED" {
+                handleExternalAuthorization(body: body, eventPayload: eventPayload, eventType: eventType)
+                return 
+            }
         }
         
         if

--- a/Sources/TruvSDK/Classes/Models/TruvEvent.swift
+++ b/Sources/TruvSDK/Classes/Models/TruvEvent.swift
@@ -12,8 +12,11 @@ public enum TruvEvent : Encodable {
         switch self {
             case .onError:
                 Vibration.error.vibrate()
-            case .onSuccess:
-                Vibration.success.vibrate()
+            case .onEvent(let eventPayload):
+                if eventPayload?.eventType == .screenView,
+                   eventPayload?.payload?.viewName == "SUCCESS" {
+                    Vibration.success.vibrate()
+                }
             default:
                 break
         }


### PR DESCRIPTION
## Description of the change

Remove return from external authorization and fix truv events handling. Added haptic feedback to success screen event.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] All tests related to the changed code pass in development
- [ ] The code is checked for the [common insecure coding practices](https://owasp.org/www-project-top-ten/) 

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
